### PR TITLE
eval_hook.py check point 함수 수정 코드스니펫

### DIFF
--- a/object detection/eval_hook_checkpoint_func_custom.py
+++ b/object detection/eval_hook_checkpoint_func_custom.py
@@ -1,0 +1,20 @@
+def save_best_checkpoint(self, runner, key_score):
+        best_score = runner.meta['hook_msgs'].get(
+            'best_score', self.init_value_map[self.rule])
+        if self.compare_func(key_score, best_score):
+            best_score = key_score
+            runner.meta['hook_msgs']['best_score'] = best_score
+            last_ckpt = runner.meta['hook_msgs']['last_ckpt']
+            runner.meta['hook_msgs']['best_ckpt'] = last_ckpt
+            # mmcv.symlink(
+            #     last_ckpt,
+            #     osp.join(runner.work_dir, f'best_{self.key_indicator}.pth'))
+            shutil.copy(
+                last_ckpt,
+                osp.join(runner.work_dir, f'best_{self.key_indicator}.pth')
+            )
+            
+            time_stamp = runner.epoch + 1 if self.by_epoch else runner.iter + 1
+            self.logger.info(f'Now best checkpoint is epoch_{time_stamp}.pth.'
+                             f'Best {self.key_indicator} is {best_score:0.4f}')
+        os.remove(osp.join(runner.work_dir,f'epoch_{runner.epoch + 1}.pth'))


### PR DESCRIPTION
mmdetection/mmedt/core/evaluation/eval_hook.py 의 save_best_checkpoint 함수에서

심볼릭링크가 아닌 실제 모델을 저장하고 , best score 모델이 아닌 pth 파일은 자동으로 삭제 되도록 함수를 수정.